### PR TITLE
fix: resolve golangci-lint errors across all files

### DIFF
--- a/internal/server/grpc_test.go
+++ b/internal/server/grpc_test.go
@@ -29,7 +29,9 @@ func TestDelete(t *testing.T) {
 	server := testhelpers.NewTestServer(t)
 	ctx := context.Background()
 
-	server.Set(ctx, &pb.SetRequest{Key: "foo", Value: []byte("bar")})
+	if _, err := server.Set(ctx, &pb.SetRequest{Key: "foo", Value: []byte("bar")}); err != nil {
+		t.Fatal(err)
+	}
 
 	_, err := server.Delete(ctx, &pb.DeleteRequest{Key: "foo"})
 	assert.NoError(t, err)
@@ -42,8 +44,12 @@ func TestClear(t *testing.T) {
 	server := testhelpers.NewTestServer(t)
 	ctx := context.Background()
 
-	server.Set(ctx, &pb.SetRequest{Key: "a", Value: []byte("1")})
-	server.Set(ctx, &pb.SetRequest{Key: "b", Value: []byte("2")})
+	if _, err := server.Set(ctx, &pb.SetRequest{Key: "a", Value: []byte("1")}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.Set(ctx, &pb.SetRequest{Key: "b", Value: []byte("2")}); err != nil {
+		t.Fatal(err)
+	}
 
 	_, err := server.Clear(ctx, &pb.ClearRequest{})
 	assert.NoError(t, err)
@@ -58,15 +64,21 @@ func TestList(t *testing.T) {
 	server := testhelpers.NewTestServer(t)
 	ctx := context.Background()
 
-	server.Set(ctx, &pb.SetRequest{Key: "a", Value: []byte("1")})
-	server.Set(ctx, &pb.SetRequest{Key: "b", Value: []byte("2")})
+	if _, err := server.Set(ctx, &pb.SetRequest{Key: "a", Value: []byte("1")}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.Set(ctx, &pb.SetRequest{Key: "b", Value: []byte("2")}); err != nil {
+		t.Fatal(err)
+	}
 
 	resp, err := server.List(ctx, &pb.ListRequest{})
 	assert.NoError(t, err)
 	assert.Contains(t, resp.Keys, "a")
 	assert.Contains(t, resp.Keys, "b")
 
-	server.Set(ctx, &pb.SetRequest{Key: "c", Value: []byte("3")})
+	if _, err := server.Set(ctx, &pb.SetRequest{Key: "c", Value: []byte("3")}); err != nil {
+		t.Fatal(err)
+	}
 	resp, err = server.List(ctx, &pb.ListRequest{})
 	assert.NoError(t, err)
 	assert.Contains(t, resp.Keys, "c")

--- a/tests/benchmark/cache_benchmark_test.go
+++ b/tests/benchmark/cache_benchmark_test.go
@@ -32,7 +32,9 @@ func BenchmarkSet(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		key := "key" + strconv.Itoa(i)
-		server.Set(ctx, &pb.SetRequest{Key: key, Value: []byte("value")})
+		if _, err := server.Set(ctx, &pb.SetRequest{Key: key, Value: []byte("value")}); err != nil {
+			b.Fatalf("Set failed: %v", err)
+		}
 	}
 }
 
@@ -43,11 +45,15 @@ func BenchmarkGet(b *testing.B) {
 
 	// Preload a key
 	key := "benchmark_key"
-	server.Set(ctx, &pb.SetRequest{Key: key, Value: []byte("value")})
+	if _, err := server.Set(ctx, &pb.SetRequest{Key: key, Value: []byte("value")}); err != nil {
+		b.Fatalf("Set failed: %v", err)
+	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		server.Get(ctx, &pb.GetRequest{Key: key})
+		if _, err := server.Get(ctx, &pb.GetRequest{Key: key}); err != nil {
+			b.Fatalf("Set failed: %v", err)
+		}
 	}
 }
 
@@ -58,8 +64,12 @@ func BenchmarkDelete(b *testing.B) {
 
 	key := "key_to_delete"
 	for i := 0; i < b.N; i++ {
-		server.Set(ctx, &pb.SetRequest{Key: key, Value: []byte("value")})
-		server.Delete(ctx, &pb.DeleteRequest{Key: key})
+		if _, err := server.Set(ctx, &pb.SetRequest{Key: key, Value: []byte("value")}); err != nil {
+			b.Fatalf("Set failed: %v", err)
+		}
+		if _, err := server.Delete(ctx, &pb.DeleteRequest{Key: key}); err != nil {
+			b.Fatalf("Set failed: %v", err)
+		}
 	}
 }
 
@@ -68,12 +78,16 @@ func BenchmarkGetParallel(b *testing.B) {
 	server := server.NewServer(testhelpers.DefaultLogger(), cfg, testhelpers.DefaultPrometheusRegistry())
 	ctx := context.Background()
 	key := "hot"
-	server.Set(ctx, &pb.SetRequest{Key: key, Value: []byte("hit")})
+	if _, err := server.Set(ctx, &pb.SetRequest{Key: key, Value: []byte("hit")}); err != nil {
+		b.Fatalf("Set failed: %v", err)
+	}
 
 	b.ResetTimer()
 	b.RunParallel(func(p *testing.PB) {
 		for p.Next() {
-			server.Get(ctx, &pb.GetRequest{Key: key})
+			if _, err := server.Get(ctx, &pb.GetRequest{Key: key}); err != nil {
+				b.Fatalf("Set failed: %v", err)
+			}
 		}
 	})
 }
@@ -86,11 +100,15 @@ func BenchmarkList(b *testing.B) {
 	// Preload some keys
 	for i := 0; i < 1000; i++ {
 		key := "key" + strconv.Itoa(i)
-		server.Set(ctx, &pb.SetRequest{Key: key, Value: []byte("value")})
+		if _, err := server.Set(ctx, &pb.SetRequest{Key: key, Value: []byte("value")}); err != nil {
+			b.Fatalf("Set failed: %v", err)
+		}
 	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		server.List(ctx, &pb.ListRequest{})
+		if _, err := server.List(ctx, &pb.ListRequest{}); err != nil {
+			b.Fatalf("Set failed: %v", err)
+		}
 	}
 }


### PR DESCRIPTION
This PR addresses all golangci-lint issues by properly handling error return values in benchmark test files to ensure code quality and linter compliance.